### PR TITLE
강원대 FE_4조 6주차 제출

### DIFF
--- a/src/api/auth/trainerLogin.ts
+++ b/src/api/auth/trainerLogin.ts
@@ -1,17 +1,10 @@
 import { LoginData } from '@/types';
+import { fetchAPI } from '..';
 
 export const trainerLogin = async ({ email, password }: LoginData) => {
-  const response = await fetch('/api/auth/trainer/login', {
+  return await fetchAPI({
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ email, password }),
+    endpoint: '/auth/trainer/login',
+    body: { email, password },
   });
-
-  if (response.status === 200) {
-    return response;
-  } else {
-    throw new Error('로그인 실패');
-  }
 };

--- a/src/api/auth/userLogin.ts
+++ b/src/api/auth/userLogin.ts
@@ -1,17 +1,10 @@
 import { LoginData } from '@/types';
+import { fetchAPI } from '..';
 
 export const userLogin = async ({ email, password }: LoginData) => {
-  const response = await fetch('/api/auth/user/login', {
+  return await fetchAPI({
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ email, password }),
+    endpoint: '/auth/user/login',
+    body: { email, password },
   });
-
-  if (response.status === 200) {
-    return response;
-  } else {
-    throw new Error('로그인 실패');
-  }
 };

--- a/src/api/bodyInfo/getBodyInfo.ts
+++ b/src/api/bodyInfo/getBodyInfo.ts
@@ -1,0 +1,16 @@
+export const getBodyInfo = async () => {
+  const token = localStorage.getItem('accessToken');
+  const response = await fetch('/api/users/bodyInfo', {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (response.status !== 200) {
+    throw new Error('이미지 데이터 가져오기 실패');
+  }
+
+  const data = await response.json();
+  return data;
+};

--- a/src/api/bodyInfo/postBodyInfo.ts
+++ b/src/api/bodyInfo/postBodyInfo.ts
@@ -2,8 +2,7 @@ export const postBodyInfo = async (formData: FormData) => {
   const token = localStorage.getItem('accessToken');
 
   try {
-    //TODO : 추후 엔드포인트 /info -> /bodyInfo 로 변경
-    const response = await fetch('/api/users/info', {
+    const response = await fetch('/api/users/bodyInfo', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,

--- a/src/api/bodyInfo/postBodyInfo.ts
+++ b/src/api/bodyInfo/postBodyInfo.ts
@@ -1,0 +1,20 @@
+export const postBodyInfo = async (formData: FormData) => {
+  const token = localStorage.getItem('accessToken');
+
+  try {
+    //TODO : 추후 엔드포인트 /info -> /bodyInfo 로 변경
+    const response = await fetch('/api/users/info', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      body: formData,
+    });
+
+    if (response.status !== 201) {
+      throw new Error('이미지 업로드 실패');
+    }
+  } catch (error) {
+    console.error('업로드 중 오류가 발생했습니다:', error);
+  }
+};

--- a/src/api/bodyInfo/postBodyInfo.ts
+++ b/src/api/bodyInfo/postBodyInfo.ts
@@ -1,19 +1,15 @@
 export const postBodyInfo = async (formData: FormData) => {
   const token = localStorage.getItem('accessToken');
 
-  try {
-    const response = await fetch('/api/users/bodyInfo', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-      body: formData,
-    });
+  const response = await fetch('/api/users/bodyInfo', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    body: formData,
+  });
 
-    if (response.status !== 201) {
-      throw new Error('이미지 업로드 실패');
-    }
-  } catch (error) {
-    console.error('업로드 중 오류가 발생했습니다:', error);
+  if (response.status !== 201) {
+    throw new Error('이미지 업로드 실패');
   }
 };

--- a/src/api/career/postCareer.ts
+++ b/src/api/career/postCareer.ts
@@ -1,0 +1,18 @@
+import { Career } from '@/types';
+
+export const postCareer = async (careers: Career[]) => {
+  const token = localStorage.getItem('accessToken');
+
+  const response = await fetch('/api/trainers/career', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(careers),
+  });
+
+  if (response.status !== 201) {
+    throw new Error('경력 업로드 실패');
+  }
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,37 @@
+const API_URL = '/api';
+
+interface FetchOptions {
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  endpoint: string;
+  body?: any;
+  headers?: HeadersInit;
+  isFormData?: boolean;
+}
+
+export const fetchAPI = async ({
+  method,
+  endpoint,
+  body,
+  headers = {},
+  isFormData = false,
+}: FetchOptions) => {
+  const token = localStorage.getItem('accessToken');
+
+  const defaultHeaders: HeadersInit = {
+    ...(token && { Authorization: `Bearer ${token}` }),
+    ...(!isFormData && { 'Content-Type': 'application/json' }),
+    ...headers,
+  };
+
+  const response = await fetch(`${API_URL}${endpoint}`, {
+    method,
+    headers: defaultHeaders,
+    body: body && !isFormData ? JSON.stringify(body) : body,
+  });
+
+  if (!response.ok) {
+    throw new Error('API 요청 실패');
+  }
+
+  return response.json();
+};

--- a/src/components/Home/TrainerHomeProfile.tsx
+++ b/src/components/Home/TrainerHomeProfile.tsx
@@ -10,9 +10,7 @@ import { useProfile } from '@/hooks/useProfile';
 export const TrainerHomeProfile = () => {
   const profile = useProfile();
 
-  // profile이 TrainerProfile 타입인지 확인
-  // TODO : 프로필 이미지 명칭 통일에 대해 백엔드와 논의 후 이 부분과 type 부분 수정
-  if (!profile || !('profileImageUrl' in profile)) {
+  if (!profile) {
     return <p>프로필 정보를 불러오는 중...</p>;
   }
 

--- a/src/components/Home/TrainerHomeProfile.tsx
+++ b/src/components/Home/TrainerHomeProfile.tsx
@@ -6,16 +6,23 @@ import {
   StyledNameText,
 } from './UserHomeProfile.styles';
 import { useProfile } from '@/hooks/useProfile';
+import { useNavigate } from 'react-router-dom';
+import { RouterPath } from '@/routes/path';
 
 export const TrainerHomeProfile = () => {
+  const navigate = useNavigate();
   const profile = useProfile();
 
   if (!profile) {
     return <p>프로필 정보를 불러오는 중...</p>;
   }
 
+  const handleProfileClick = () => {
+    navigate(RouterPath.mypage);
+  };
+
   return (
-    <Wrapper>
+    <Wrapper onClick={handleProfileClick} style={{ cursor: 'pointer' }}>
       <Card>
         <StyledCardBody>
           <StyledProfileImage src={profile.profileImageUrl} alt='프로필' />

--- a/src/components/Home/TrainerHomeProfile.tsx
+++ b/src/components/Home/TrainerHomeProfile.tsx
@@ -22,7 +22,7 @@ export const TrainerHomeProfile = () => {
   };
 
   return (
-    <Wrapper onClick={handleProfileClick} style={{ cursor: 'pointer' }}>
+    <Wrapper onClick={handleProfileClick}>
       <Card>
         <StyledCardBody>
           <StyledProfileImage src={profile.profileImageUrl} alt='프로필' />

--- a/src/components/Home/UserHomeProfile.styles.ts
+++ b/src/components/Home/UserHomeProfile.styles.ts
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 export const Wrapper = styled.div`
   margin-top: 30px;
+  cursor: pointer;
 `;
 
 export const StyledCardBody = styled(CardBody)`

--- a/src/components/Home/UserHomeProfile.tsx
+++ b/src/components/Home/UserHomeProfile.tsx
@@ -6,16 +6,23 @@ import {
   StyledNameText,
 } from './UserHomeProfile.styles';
 import { useProfile } from '@/hooks/useProfile';
+import { useNavigate } from 'react-router-dom';
+import { RouterPath } from '@/routes/path';
 
 export const UserHomeProfile = () => {
+  const navigate = useNavigate();
   const profile = useProfile();
 
   if (!profile) {
     return <p>프로필 정보를 불러오는 중...</p>;
   }
 
+  const handleProfileClick = () => {
+    navigate(RouterPath.mypage);
+  };
+
   return (
-    <Wrapper>
+    <Wrapper onClick={handleProfileClick} style={{ cursor: 'pointer' }}>
       <Card>
         <StyledCardBody>
           <StyledProfileImage src={profile.profileImageUrl} alt='프로필' />

--- a/src/components/Home/UserHomeProfile.tsx
+++ b/src/components/Home/UserHomeProfile.tsx
@@ -10,8 +10,7 @@ import { useProfile } from '@/hooks/useProfile';
 export const UserHomeProfile = () => {
   const profile = useProfile();
 
-  // profile이 UserProfile 타입인지 확인
-  if (!profile || !('profileImageUrl' in profile)) {
+  if (!profile) {
     return <p>프로필 정보를 불러오는 중...</p>;
   }
 

--- a/src/components/Home/UserHomeProfile.tsx
+++ b/src/components/Home/UserHomeProfile.tsx
@@ -22,7 +22,7 @@ export const UserHomeProfile = () => {
   };
 
   return (
-    <Wrapper onClick={handleProfileClick} style={{ cursor: 'pointer' }}>
+    <Wrapper onClick={handleProfileClick}>
       <Card>
         <StyledCardBody>
           <StyledProfileImage src={profile.profileImageUrl} alt='프로필' />

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -26,7 +26,7 @@ export const Header = () => {
       <UserWrapper>
         {isAuthenticated ? (
           <>
-            <StyledLink to={RouterPath.login}>내정보</StyledLink>
+            <StyledLink to={RouterPath.mypage}>내정보</StyledLink>
             <Text fontSize='xs'>/</Text>
             <StyledButton onClick={handleLogout}>로그아웃</StyledButton>
           </>

--- a/src/components/MyPage/Profile/TrainerMyPageProfile.tsx
+++ b/src/components/MyPage/Profile/TrainerMyPageProfile.tsx
@@ -1,0 +1,27 @@
+import { Card } from '@chakra-ui/react';
+import {
+  Wrapper,
+  StyledCardBody,
+  StyledProfileImage,
+  StyledNameText,
+} from '../../Home/UserHomeProfile.styles';
+import { useProfile } from '@/hooks/useProfile';
+
+export const TrainerMyPageProfile = () => {
+  const profile = useProfile();
+
+  if (!profile) {
+    return <p>프로필 정보를 불러오는 중...</p>;
+  }
+
+  return (
+    <Wrapper>
+      <Card>
+        <StyledCardBody>
+          <StyledProfileImage src={profile.profileImageUrl} alt='프로필' />
+          <StyledNameText mt='15px'>{profile.name} 님</StyledNameText>
+        </StyledCardBody>
+      </Card>
+    </Wrapper>
+  );
+};

--- a/src/components/MyPage/Profile/UserMyPageProfile.tsx
+++ b/src/components/MyPage/Profile/UserMyPageProfile.tsx
@@ -1,0 +1,27 @@
+import { Card } from '@chakra-ui/react';
+import {
+  Wrapper,
+  StyledCardBody,
+  StyledProfileImage,
+  StyledNameText,
+} from '../../Home/UserHomeProfile.styles';
+import { useProfile } from '@/hooks/useProfile';
+
+export const UserMyPageProfile = () => {
+  const profile = useProfile();
+
+  if (!profile) {
+    return <p>프로필 정보를 불러오는 중...</p>;
+  }
+
+  return (
+    <Wrapper>
+      <Card>
+        <StyledCardBody>
+          <StyledProfileImage src={profile.profileImageUrl} alt='프로필' />
+          <StyledNameText mt='15px'>{profile.name} 님</StyledNameText>
+        </StyledCardBody>
+      </Card>
+    </Wrapper>
+  );
+};

--- a/src/components/MyPage/UserBodyInfo.styles.ts
+++ b/src/components/MyPage/UserBodyInfo.styles.ts
@@ -1,0 +1,40 @@
+import { colors } from '@/styles/colors';
+import { Box, Button, Card, Text } from '@chakra-ui/react';
+import styled from '@emotion/styled';
+
+export const StyledCard = styled(Card)`
+  margin: 20px 0px;
+  padding-bottom: 20px;
+`;
+
+export const StyledTitleText = styled(Text)`
+  text-align: center;
+  font-size: 20px;
+  font-weight: 600;
+  margin: 20px 0px 30px;
+`;
+
+export const HistoryBox = styled(Box)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 8px;
+`;
+
+export const StyledDateText = styled(Text)`
+  margin: 10px 50px 0px 20px;
+  font-size: 18px;
+`;
+
+export const StyledButton = styled(Button)`
+  background-color: ${colors.mainColor};
+  color: ${colors.white};
+  border-radius: 20px;
+  font-size: 12px;
+  height: 28px;
+  margin-top: 8px;
+
+  &:hover {
+    background-color: #ff467e;
+  }
+`;

--- a/src/components/MyPage/UserBodyInfo.tsx
+++ b/src/components/MyPage/UserBodyInfo.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+  Image,
+  Text,
+} from '@chakra-ui/react';
+import { useBodyInfo } from '@/hooks/useBodyInfo';
+import {
+  StyledButton,
+  StyledCard,
+  HistoryBox,
+  StyledDateText,
+  StyledTitleText,
+} from './UserBodyInfo.styles';
+export const UserBodyInfo = () => {
+  const { bodyInfo } = useBodyInfo();
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+
+  const openModal = (imageUrl: string) => {
+    setSelectedImage(imageUrl);
+    setIsOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsOpen(false);
+    setSelectedImage(null);
+  };
+
+  return (
+    <StyledCard>
+      <StyledTitleText>&#128196; 나의 히스토리</StyledTitleText>
+      {bodyInfo.length === 0 ? (
+        <Text>등록된 인바디 이미지가 없습니다.</Text>
+      ) : (
+        bodyInfo.map((info) => (
+          <HistoryBox key={info.infoId}>
+            <StyledDateText>
+              {new Date(info.createDate).toLocaleDateString()}
+            </StyledDateText>
+            <StyledButton onClick={() => openModal(info.inbodyImageUrl)}>
+              인바디 이미지
+            </StyledButton>
+          </HistoryBox>
+        ))
+      )}
+
+      <Modal isOpen={isOpen} onClose={closeModal}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>인바디 이미지</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            {selectedImage && <Image src={selectedImage} alt='Inbody' />}
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    </StyledCard>
+  );
+};

--- a/src/hooks/useBodyInfo.ts
+++ b/src/hooks/useBodyInfo.ts
@@ -1,0 +1,18 @@
+import { postBodyInfo } from '@/api/bodyInfo/postBodyInfo';
+
+export const useBodyInfo = () => {
+  const handleUploadBodyInfo = async (formData: FormData) => {
+    try {
+      await postBodyInfo(formData);
+
+      alert('이미지가 성공적으로 업로드되었습니다.');
+      return true;
+    } catch (error) {
+      console.error('이미지 업로드 실패:', error);
+      alert('이미지 업로드에 실패했습니다.');
+      return false;
+    }
+  };
+
+  return { handleUploadBodyInfo };
+};

--- a/src/hooks/useBodyInfo.ts
+++ b/src/hooks/useBodyInfo.ts
@@ -1,11 +1,18 @@
+import { getBodyInfo } from '@/api/bodyInfo/getBodyInfo';
 import { postBodyInfo } from '@/api/bodyInfo/postBodyInfo';
+import { RouterPath } from '@/routes/path';
+import { BodyInfo } from '@/types';
+import { useEffect, useState } from 'react';
 
 export const useBodyInfo = () => {
+  const [bodyInfo, setBodyInfo] = useState<BodyInfo[]>([]);
+
   const handleUploadBodyInfo = async (formData: FormData) => {
     try {
       await postBodyInfo(formData);
 
       alert('이미지가 성공적으로 업로드되었습니다.');
+      window.location.replace(RouterPath.mypage);
       return true;
     } catch (error) {
       console.error('이미지 업로드 실패:', error);
@@ -14,5 +21,18 @@ export const useBodyInfo = () => {
     }
   };
 
-  return { handleUploadBodyInfo };
+  useEffect(() => {
+    const fetchBodyInfo = async () => {
+      try {
+        const data = await getBodyInfo();
+        setBodyInfo(data);
+      } catch (error) {
+        console.error('인바디 이미지 데이터를 가져오는데 실패했습니다.', error);
+      }
+    };
+
+    fetchBodyInfo();
+  }, []);
+
+  return { bodyInfo, handleUploadBodyInfo };
 };

--- a/src/hooks/useBodyInfo.ts
+++ b/src/hooks/useBodyInfo.ts
@@ -13,11 +13,9 @@ export const useBodyInfo = () => {
 
       alert('이미지가 성공적으로 업로드되었습니다.');
       window.location.replace(RouterPath.mypage);
-      return true;
     } catch (error) {
       console.error('이미지 업로드 실패:', error);
       alert('이미지 업로드에 실패했습니다.');
-      return false;
     }
   };
 

--- a/src/hooks/useCareer.ts
+++ b/src/hooks/useCareer.ts
@@ -7,11 +7,9 @@ export const useCareer = () => {
       await postCareer(careers);
 
       alert('경력이 성공적으로 업로드되었습니다.');
-      return true;
     } catch (error) {
       console.error('경력 업로드 실패:', error);
       alert('경력 업로드에 실패했습니다.');
-      return false;
     }
   };
 

--- a/src/hooks/useCareer.ts
+++ b/src/hooks/useCareer.ts
@@ -1,0 +1,19 @@
+import { postCareer } from '@/api/career/postCareer';
+import { Career } from '@/types';
+
+export const useCareer = () => {
+  const handleUploadCareer = async (careers: Career[]) => {
+    try {
+      await postCareer(careers);
+
+      alert('경력이 성공적으로 업로드되었습니다.');
+      return true;
+    } catch (error) {
+      console.error('경력 업로드 실패:', error);
+      alert('경력 업로드에 실패했습니다.');
+      return false;
+    }
+  };
+
+  return { handleUploadCareer };
+};

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -27,7 +27,7 @@ export const useLogin = () => {
 
       alert('로그인에 성공했습니다.');
 
-      const token = await response.text();
+      const { token } = await response;
       localStorage.setItem('accessToken', token);
       localStorage.setItem('type', loginType);
 

--- a/src/pages/BodyInfo/RegisterBodyInfo.styles.ts
+++ b/src/pages/BodyInfo/RegisterBodyInfo.styles.ts
@@ -1,3 +1,4 @@
+import { colors } from '@/styles/colors';
 import { Button, Text } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 
@@ -28,17 +29,17 @@ export const FileWrapper = styled.div`
 
 export const StyledFileButton = styled(Button)`
   background-color: #4f4f4f;
-  color: #f5f5f5;
+  color: ${colors.white};
   &:hover {
-    background-color: #2c2c2c;
+    background-color: ${colors.black};
   }
   margin-bottom: 20px;
   width: 100%;
 `;
 
 export const StyledUploadButton = styled(Button)`
-  background-color: #ff1658;
-  color: #f5f5f5;
+  background-color: ${colors.mainColor};
+  color: ${colors.white};
   &:hover {
     background-color: #ff467e;
   }

--- a/src/pages/BodyInfo/RegisterBodyInfo.styles.ts
+++ b/src/pages/BodyInfo/RegisterBodyInfo.styles.ts
@@ -1,0 +1,46 @@
+import { Button, Text } from '@chakra-ui/react';
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div``;
+
+export const StyledTitleText = styled(Text)`
+  margin: 50px 30px 40px;
+  font-size: 28px;
+  font-weight: 700;
+`;
+
+export const StyledMiddleText = styled(Text)`
+  margin: 10px 30px 0;
+  font-size: 20px;
+  font-weight: 500;
+`;
+export const StyledText = styled(Text)`
+  margin: 0 30px;
+  font-size: 15px;
+`;
+
+export const FileWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 30px 0;
+`;
+
+export const StyledFileButton = styled(Button)`
+  background-color: #4f4f4f;
+  color: #f5f5f5;
+  &:hover {
+    background-color: #2c2c2c;
+  }
+  margin-bottom: 20px;
+  width: 100%;
+`;
+
+export const StyledUploadButton = styled(Button)`
+  background-color: #ff1658;
+  color: #f5f5f5;
+  &:hover {
+    background-color: #ff467e;
+  }
+  width: 100%;
+`;

--- a/src/pages/BodyInfo/RegisterBodyInfo.tsx
+++ b/src/pages/BodyInfo/RegisterBodyInfo.tsx
@@ -11,8 +11,12 @@ import {
 } from './RegisterBodyInfo.styles';
 import { PlusSquareIcon } from '@chakra-ui/icons';
 import { useBodyInfo } from '@/hooks/useBodyInfo';
+import { useNavigate } from 'react-router-dom';
+import { RouterPath } from '@/routes/path';
 
 export const RegisterBodyInfo = () => {
+  const navigate = useNavigate();
+
   const { handleUploadBodyInfo } = useBodyInfo();
 
   const [selectedImage, setSelectedImage] = useState<File | null>(null);
@@ -37,6 +41,7 @@ export const RegisterBodyInfo = () => {
     formData.append('inbodyImage', selectedImage);
 
     handleUploadBodyInfo(formData);
+    navigate(RouterPath.mypage);
   };
 
   const handleClickFileInput = () => {

--- a/src/pages/BodyInfo/RegisterBodyInfo.tsx
+++ b/src/pages/BodyInfo/RegisterBodyInfo.tsx
@@ -1,0 +1,89 @@
+import { Box, Icon, Image } from '@chakra-ui/react';
+import { useRef, useState } from 'react';
+import {
+  FileWrapper,
+  StyledFileButton,
+  StyledMiddleText,
+  StyledText,
+  StyledTitleText,
+  StyledUploadButton,
+  Wrapper,
+} from './RegisterBodyInfo.styles';
+import { PlusSquareIcon } from '@chakra-ui/icons';
+import { useBodyInfo } from '@/hooks/useBodyInfo';
+
+export const RegisterBodyInfo = () => {
+  const { handleUploadBodyInfo } = useBodyInfo();
+
+  const [selectedImage, setSelectedImage] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null); // 파일 선택 Input을 참조
+
+  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      setSelectedImage(file);
+      setPreview(URL.createObjectURL(file));
+    }
+  };
+
+  const handleImageUpload = async () => {
+    if (!selectedImage) {
+      alert('이미지를 선택해주세요.');
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('inbodyImage', selectedImage);
+
+    handleUploadBodyInfo(formData);
+  };
+
+  const handleClickFileInput = () => {
+    fileInputRef.current?.click(); // 숨겨진 파일 선택 input을 클릭
+  };
+
+  return (
+    <Wrapper>
+      <StyledTitleText>회원님에 대해서 알려주세요.</StyledTitleText>
+      <StyledMiddleText>인바디 검사 결과지를 공유해주세요.</StyledMiddleText>
+      <StyledText>
+        트레이너가 참고하여 나에게 더 알맞는 매칭이 가능해요.
+      </StyledText>
+      <FileWrapper>
+        <input
+          type='file'
+          accept='image/*'
+          ref={fileInputRef}
+          onChange={handleImageChange}
+          style={{ display: 'none' }} // 숨기기
+        />
+
+        <StyledFileButton
+          onClick={handleClickFileInput}
+          leftIcon={<Icon as={PlusSquareIcon} boxSize={5} />}
+        >
+          파일 선택
+        </StyledFileButton>
+
+        {preview && (
+          <Box mt={8} mb={8}>
+            <Image
+              src={preview}
+              alt='미리보기'
+              boxSize='300px'
+              objectFit='cover'
+            />
+          </Box>
+        )}
+
+        <StyledUploadButton
+          onClick={handleImageUpload}
+          isDisabled={!selectedImage}
+        >
+          이미지 업로드
+        </StyledUploadButton>
+      </FileWrapper>
+    </Wrapper>
+  );
+};

--- a/src/pages/BodyInfo/RegisterBodyInfo.tsx
+++ b/src/pages/BodyInfo/RegisterBodyInfo.tsx
@@ -11,12 +11,8 @@ import {
 } from './RegisterBodyInfo.styles';
 import { PlusSquareIcon } from '@chakra-ui/icons';
 import { useBodyInfo } from '@/hooks/useBodyInfo';
-import { useNavigate } from 'react-router-dom';
-import { RouterPath } from '@/routes/path';
 
 export const RegisterBodyInfo = () => {
-  const navigate = useNavigate();
-
   const { handleUploadBodyInfo } = useBodyInfo();
 
   const [selectedImage, setSelectedImage] = useState<File | null>(null);
@@ -41,7 +37,6 @@ export const RegisterBodyInfo = () => {
     formData.append('inbodyImage', selectedImage);
 
     handleUploadBodyInfo(formData);
-    navigate(RouterPath.mypage);
   };
 
   const handleClickFileInput = () => {

--- a/src/pages/Career/RegisterCareer.styles.ts
+++ b/src/pages/Career/RegisterCareer.styles.ts
@@ -1,3 +1,4 @@
+import { colors } from '@/styles/colors';
 import { Button, Input, Text } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 
@@ -20,17 +21,17 @@ export const StyledInput = styled(Input)`
 
 export const StyledAddButton = styled(Button)`
   background-color: #4f4f4f;
-  color: #f5f5f5;
+  color: ${colors.white};
   &:hover {
-    background-color: #2c2c2c;
+    background-color: ${colors.black};
   }
   margin: 20px 0 10px;
   width: 100%;
 `;
 
 export const StyledUploadButton = styled(Button)`
-  background-color: #ff1658;
-  color: #f5f5f5;
+  background-color: ${colors.mainColor};
+  color: ${colors.white};
   &:hover {
     background-color: #ff467e;
   }

--- a/src/pages/Career/RegisterCareer.styles.ts
+++ b/src/pages/Career/RegisterCareer.styles.ts
@@ -1,0 +1,38 @@
+import { Button, Input, Text } from '@chakra-ui/react';
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div``;
+
+export const StyledTitleText = styled(Text)`
+  margin: 50px 30px 40px;
+  font-size: 28px;
+  font-weight: 700;
+`;
+
+export const StyledMiddleText = styled(Text)`
+  margin: 10px 30px 20px;
+  font-size: 20px;
+  font-weight: 500;
+`;
+export const StyledInput = styled(Input)`
+  margin: 5px 20px;
+`;
+
+export const StyledAddButton = styled(Button)`
+  background-color: #4f4f4f;
+  color: #f5f5f5;
+  &:hover {
+    background-color: #2c2c2c;
+  }
+  margin: 20px 0 10px;
+  width: 100%;
+`;
+
+export const StyledUploadButton = styled(Button)`
+  background-color: #ff1658;
+  color: #f5f5f5;
+  &:hover {
+    background-color: #ff467e;
+  }
+  width: 100%;
+`;

--- a/src/pages/Career/RegisterCareer.tsx
+++ b/src/pages/Career/RegisterCareer.tsx
@@ -1,0 +1,67 @@
+import { Box, Button, Icon, Input } from '@chakra-ui/react';
+import { useState } from 'react';
+import {
+  StyledAddButton,
+  StyledInput,
+  StyledMiddleText,
+  StyledTitleText,
+  StyledUploadButton,
+  Wrapper,
+} from './RegisterCareer.styles';
+import { AddIcon } from '@chakra-ui/icons';
+import { Career } from '@/types';
+import { useCareer } from '@/hooks/useCareer';
+import { useNavigate } from 'react-router-dom';
+import { RouterPath } from '@/routes/path';
+
+export const RegisterCareer = () => {
+  const navigate = useNavigate();
+  const [careers, setCareers] = useState<Career[]>([{ career: '' }]);
+  const { handleUploadCareer } = useCareer();
+
+  const addCareer = () => {
+    setCareers([...careers, { career: '' }]);
+  };
+
+  const handleCareerChange = (index: number, value: string) => {
+    const updatedCareers = careers.map((career, i) =>
+      i === index ? { ...career, career: value } : career
+    );
+    setCareers(updatedCareers);
+  };
+
+  const handleCareerSubmit = () => {
+    handleUploadCareer(careers);
+    navigate(RouterPath.mypage);
+  };
+
+  return (
+    <Wrapper>
+      <StyledTitleText>트레이너님에 대해서 알려주세요.</StyledTitleText>
+      <StyledMiddleText>경력 및 자격사항을 알려주세요.</StyledMiddleText>
+
+      {careers.map((career, index) => (
+        <Box key={index}>
+          <StyledInput
+            placeholder='경력 및 자격사항을 입력하세요'
+            value={career.career}
+            onChange={(e) => handleCareerChange(index, e.target.value)}
+          />
+        </Box>
+      ))}
+
+      <StyledAddButton
+        onClick={addCareer}
+        leftIcon={<Icon as={AddIcon} boxSize={3} />}
+      >
+        추가하기
+      </StyledAddButton>
+      <StyledUploadButton
+        onClick={handleCareerSubmit}
+        isDisabled={!careers.length}
+      >
+        확인
+      </StyledUploadButton>
+    </Wrapper>
+  );
+};

--- a/src/pages/Login/index.styles.ts
+++ b/src/pages/Login/index.styles.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 export const Wrapper = styled.div`
   display: flex;
-  justify-content: spcae-between;
+  justify-content: space-between;
   margin: 60px auto;
 `;
 
@@ -11,14 +11,27 @@ export const LoginWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100%;
 `;
 
 export const TitleWrapper = styled.div`
   display: flex;
+  justify-content: center;
+  width: 100%;
 `;
 
 export const FormWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  width: 80%;
+  width: 100%;
+`;
+
+export const StyledForm = styled.form`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+`;
+
+export const FormControlWrapper = styled.div`
+  width: 100%;
 `;

--- a/src/pages/MyPage/TrainerMyPage.styles.ts
+++ b/src/pages/MyPage/TrainerMyPage.styles.ts
@@ -1,0 +1,17 @@
+import { Button } from '@chakra-ui/react';
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const StyledButton = styled(Button)`
+  background-color: #ff1658;
+  color: #f5f5f5;
+  margin-top: 24px;
+
+  &:hover {
+    background-color: #ff467e;
+  }
+`;

--- a/src/pages/MyPage/TrainerMyPage.styles.ts
+++ b/src/pages/MyPage/TrainerMyPage.styles.ts
@@ -1,3 +1,4 @@
+import { colors } from '@/styles/colors';
 import { Button } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 
@@ -7,8 +8,8 @@ export const Wrapper = styled.div`
 `;
 
 export const StyledButton = styled(Button)`
-  background-color: #ff1658;
-  color: #f5f5f5;
+  background-color: ${colors.mainColor};
+  color: ${colors.white};
   margin-top: 24px;
 
   &:hover {

--- a/src/pages/MyPage/TrainerMyPage.tsx
+++ b/src/pages/MyPage/TrainerMyPage.tsx
@@ -1,0 +1,3 @@
+export const TrainerMyPage = () => {
+  return <p>트레이너 마이페이지</p>;
+};

--- a/src/pages/MyPage/TrainerMyPage.tsx
+++ b/src/pages/MyPage/TrainerMyPage.tsx
@@ -1,3 +1,21 @@
+import { TrainerMyPageProfile } from '@/components/MyPage/Profile/TrainerMyPageProfile';
+import { StyledButton, Wrapper } from './TrainerMyPage.styles';
+import { useNavigate } from 'react-router-dom';
+import { RouterPath } from '@/routes/path';
+
 export const TrainerMyPage = () => {
-  return <p>트레이너 마이페이지</p>;
+  const navigate = useNavigate();
+
+  const navigateToRegisterCareer = () => {
+    navigate(RouterPath.registerCareer);
+  };
+
+  return (
+    <Wrapper>
+      <TrainerMyPageProfile />
+      <StyledButton type='button' onClick={navigateToRegisterCareer}>
+        경력 등록하기
+      </StyledButton>
+    </Wrapper>
+  );
 };

--- a/src/pages/MyPage/UserMyPage.styles.ts
+++ b/src/pages/MyPage/UserMyPage.styles.ts
@@ -1,0 +1,17 @@
+import { Button } from '@chakra-ui/react';
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const StyledButton = styled(Button)`
+  background-color: #ff1658;
+  color: #f5f5f5;
+  margin-top: 24px;
+
+  &:hover {
+    background-color: #ff467e;
+  }
+`;

--- a/src/pages/MyPage/UserMyPage.styles.ts
+++ b/src/pages/MyPage/UserMyPage.styles.ts
@@ -1,3 +1,4 @@
+import { colors } from '@/styles/colors';
 import { Button } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 
@@ -7,8 +8,8 @@ export const Wrapper = styled.div`
 `;
 
 export const StyledButton = styled(Button)`
-  background-color: #ff1658;
-  color: #f5f5f5;
+  background-color: ${colors.mainColor};
+  color: ${colors.white};
   margin-top: 24px;
 
   &:hover {

--- a/src/pages/MyPage/UserMyPage.tsx
+++ b/src/pages/MyPage/UserMyPage.tsx
@@ -2,6 +2,7 @@ import { UserMyPageProfile } from '@/components/MyPage/Profile/UserMyPageProfile
 import { StyledButton, Wrapper } from './UserMyPage.styles';
 import { useNavigate } from 'react-router-dom';
 import { RouterPath } from '@/routes/path';
+import { UserBodyInfo } from '@/components/MyPage/UserBodyInfo';
 
 export const UserMyPage = () => {
   const navigate = useNavigate();
@@ -16,6 +17,7 @@ export const UserMyPage = () => {
       <StyledButton type='button' onClick={navigateToRegisterInbody}>
         인바디 이미지 등록하기
       </StyledButton>
+      <UserBodyInfo />
     </Wrapper>
   );
 };

--- a/src/pages/MyPage/UserMyPage.tsx
+++ b/src/pages/MyPage/UserMyPage.tsx
@@ -1,3 +1,21 @@
+import { UserMyPageProfile } from '@/components/MyPage/Profile/UserMyPageProfile';
+import { StyledButton, Wrapper } from './UserMyPage.styles';
+import { useNavigate } from 'react-router-dom';
+import { RouterPath } from '@/routes/path';
+
 export const UserMyPage = () => {
-  return <p>일반회원 마이페이지</p>;
+  const navigate = useNavigate();
+
+  const navigateToRegisterInbody = () => {
+    navigate(RouterPath.registerInbody);
+  };
+
+  return (
+    <Wrapper>
+      <UserMyPageProfile />
+      <StyledButton type='button' onClick={navigateToRegisterInbody}>
+        인바디 이미지 등록하기
+      </StyledButton>
+    </Wrapper>
+  );
 };

--- a/src/pages/MyPage/UserMyPage.tsx
+++ b/src/pages/MyPage/UserMyPage.tsx
@@ -1,0 +1,3 @@
+export const UserMyPage = () => {
+  return <p>일반회원 마이페이지</p>;
+};

--- a/src/pages/MyPage/UserMyPage.tsx
+++ b/src/pages/MyPage/UserMyPage.tsx
@@ -7,7 +7,7 @@ export const UserMyPage = () => {
   const navigate = useNavigate();
 
   const navigateToRegisterInbody = () => {
-    navigate(RouterPath.registerInbody);
+    navigate(RouterPath.registerBodyInfo);
   };
 
   return (

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,0 +1,18 @@
+import { useAuth } from '@/hooks/useAuth';
+import { UserMyPage } from './UserMyPage';
+import { TrainerMyPage } from './TrainerMyPage';
+
+export const MyPage = () => {
+  const { type } = useAuth();
+
+  const renderMyPageScreen = () => {
+    switch (type) {
+      case 'user':
+        return <UserMyPage />;
+      case 'trainer':
+        return <TrainerMyPage />;
+    }
+  };
+
+  return <div>{renderMyPageScreen()}</div>;
+};

--- a/src/pages/Signup/UserSignup.tsx
+++ b/src/pages/Signup/UserSignup.tsx
@@ -32,17 +32,22 @@ export const UserSignupPage = () => {
   const [address, setAddress] = useState('');
 
   const handleAddressComplete = (data: any) => {
+    // 기본 주소를 data에서 가져와 fullAddress에 저장
     let fullAddress = data.address;
     let extraAddress = '';
 
+    // 주소 타입이 'R'인 경우(도로명 주소)
     if (data.addressType === 'R') {
+      // 동 이름(bname)이 있으면 extraAddress에 추가
       if (data.bname !== '') {
         extraAddress += data.bname;
       }
+      // 건물 이름(buildingName)이 있으면 추가, 이미 동 이름이 있을 경우 콤마로 구분
       if (data.buildingName !== '') {
         extraAddress +=
           extraAddress !== '' ? `, ${data.buildingName}` : data.buildingName;
       }
+      // 추가 주소 정보가 있으면 괄호로 묶어서 fullAddress에 추가
       fullAddress += extraAddress !== '' ? ` (${extraAddress})` : '';
     }
 

--- a/src/pages/Signup/UserSignup.tsx
+++ b/src/pages/Signup/UserSignup.tsx
@@ -32,6 +32,7 @@ export const UserSignupPage = () => {
   const [address, setAddress] = useState('');
 
   // react-daum-postcode 예제 코드 사용
+  // https://www.npmjs.com/package/react-daum-postcode 참고
   const handleAddressComplete = (data: any) => {
     let fullAddress = data.address;
     let extraAddress = '';

--- a/src/pages/Signup/UserSignup.tsx
+++ b/src/pages/Signup/UserSignup.tsx
@@ -31,23 +31,19 @@ export const UserSignupPage = () => {
 
   const [address, setAddress] = useState('');
 
+  // react-daum-postcode 예제 코드 사용
   const handleAddressComplete = (data: any) => {
-    // 기본 주소를 data에서 가져와 fullAddress에 저장
     let fullAddress = data.address;
     let extraAddress = '';
 
-    // 주소 타입이 'R'인 경우(도로명 주소)
     if (data.addressType === 'R') {
-      // 동 이름(bname)이 있으면 extraAddress에 추가
       if (data.bname !== '') {
         extraAddress += data.bname;
       }
-      // 건물 이름(buildingName)이 있으면 추가, 이미 동 이름이 있을 경우 콤마로 구분
       if (data.buildingName !== '') {
         extraAddress +=
           extraAddress !== '' ? `, ${data.buildingName}` : data.buildingName;
       }
-      // 추가 주소 정보가 있으면 괄호로 묶어서 fullAddress에 추가
       fullAddress += extraAddress !== '' ? ` (${extraAddress})` : '';
     }
 

--- a/src/pages/Signup/index.styles.ts
+++ b/src/pages/Signup/index.styles.ts
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { Card, Text } from '@chakra-ui/react';
+import { colors } from '@/styles/colors';
 
 export const Wrapper = styled.div`
   display: flex;
@@ -34,7 +35,7 @@ export const RoleText = styled(Text)`
   font-size: 20px;
   font-weight: bold;
   text-align: center;
-  color: #2c2c2c;
+  color: ${colors.black};
   margin-top: 6px;
 `;
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -6,6 +6,7 @@ import { SignupPage } from '@/pages/Signup';
 import { UserSignupPage } from '@/pages/Signup/UserSignup';
 import { TrainerSignupPage } from '@/pages/Signup/TrainerSignup';
 import { LoginPage } from '@/pages/Login';
+import { MyPage } from '@/pages/MyPage';
 
 const router = createBrowserRouter([
   {
@@ -31,6 +32,10 @@ const router = createBrowserRouter([
       {
         path: RouterPath.signupTrainer,
         element: <TrainerSignupPage />,
+      },
+      {
+        path: RouterPath.mypage,
+        element: <MyPage />,
       },
     ],
   },

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,6 +7,7 @@ import { UserSignupPage } from '@/pages/Signup/UserSignup';
 import { TrainerSignupPage } from '@/pages/Signup/TrainerSignup';
 import { LoginPage } from '@/pages/Login';
 import { MyPage } from '@/pages/MyPage';
+import { RegisterInbody } from '@/pages/Info/RegisterInbody';
 
 const router = createBrowserRouter([
   {
@@ -36,6 +37,10 @@ const router = createBrowserRouter([
       {
         path: RouterPath.mypage,
         element: <MyPage />,
+      },
+      {
+        path: RouterPath.registerInbody,
+        element: <RegisterInbody />,
       },
     ],
   },

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,7 +7,7 @@ import { UserSignupPage } from '@/pages/Signup/UserSignup';
 import { TrainerSignupPage } from '@/pages/Signup/TrainerSignup';
 import { LoginPage } from '@/pages/Login';
 import { MyPage } from '@/pages/MyPage';
-import { RegisterInbody } from '@/pages/Info/RegisterInbody';
+import { RegisterBodyInfo } from '@/pages/BodyInfo/RegisterBodyInfo';
 
 const router = createBrowserRouter([
   {
@@ -39,8 +39,8 @@ const router = createBrowserRouter([
         element: <MyPage />,
       },
       {
-        path: RouterPath.registerInbody,
-        element: <RegisterInbody />,
+        path: RouterPath.registerBodyInfo,
+        element: <RegisterBodyInfo />,
       },
     ],
   },

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,6 +8,7 @@ import { TrainerSignupPage } from '@/pages/Signup/TrainerSignup';
 import { LoginPage } from '@/pages/Login';
 import { MyPage } from '@/pages/MyPage';
 import { RegisterBodyInfo } from '@/pages/BodyInfo/RegisterBodyInfo';
+import { RegisterCareer } from '@/pages/Career/RegisterCareer';
 
 const router = createBrowserRouter([
   {
@@ -41,6 +42,10 @@ const router = createBrowserRouter([
       {
         path: RouterPath.registerBodyInfo,
         element: <RegisterBodyInfo />,
+      },
+      {
+        path: RouterPath.registerCareer,
+        element: <RegisterCareer />,
       },
     ],
   },

--- a/src/routes/path.ts
+++ b/src/routes/path.ts
@@ -7,4 +7,5 @@ export const RouterPath = {
   signupTrainer: '/signup/trainer',
   mypage: '/mypage',
   registerBodyInfo: '/registerBodyInfo',
+  registerCareer: '/registerCareer',
 };

--- a/src/routes/path.ts
+++ b/src/routes/path.ts
@@ -6,4 +6,5 @@ export const RouterPath = {
   signupUser: '/signup/user',
   signupTrainer: '/signup/trainer',
   mypage: '/mypage',
+  registerInbody: '/registerInbody',
 };

--- a/src/routes/path.ts
+++ b/src/routes/path.ts
@@ -5,4 +5,5 @@ export const RouterPath = {
   signup: '/signup',
   signupUser: '/signup/user',
   signupTrainer: '/signup/trainer',
+  mypage: '/mypage',
 };

--- a/src/routes/path.ts
+++ b/src/routes/path.ts
@@ -6,5 +6,5 @@ export const RouterPath = {
   signupUser: '/signup/user',
   signupTrainer: '/signup/trainer',
   mypage: '/mypage',
-  registerInbody: '/registerInbody',
+  registerBodyInfo: '/registerBodyInfo',
 };

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -1,5 +1,5 @@
 export const colors = {
-  mainColor: '#ff467e',
+  mainColor: '#ff1658',
   white: '#F5F5F5',
   black: '#2C2C2C',
 };

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -1,0 +1,5 @@
+export const colors = {
+  mainColor: '#ff467e',
+  white: '#F5F5F5',
+  black: '#2C2C2C',
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,3 +45,9 @@ export interface TrainerProfile {
 export interface Career {
   career: string;
 }
+
+export interface BodyInfo {
+  infoId: number;
+  inbodyImageUrl: string;
+  createDate: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,3 +41,7 @@ export interface TrainerProfile {
   name: string;
   gender: string;
 }
+
+export interface Career {
+  career: string;
+}


### PR DESCRIPTION
## 💻 구현한 내용
- 일반회원/트레이너회원 마이페이지 추가
- 헤더에서 ‘내정보’ 클릭 시 & 홈화면에서 프로필 클릭 시 마이페이지로 이동
- 일반회원 인바디이미지 등록 기능 구현
- 트레이너회원 경력 등록 기능 구현

## ❓ 멘토님께 질문하고 싶은 내용
### `navigate` 호출 위치
저번 주차 코드리뷰에서도 `navigate`에 대하여 질문했었는데요.
약간 다른 질문이 또 생겨서 질문드려요!

현재 저는 페이지 컴포넌트 -> 관련 커스텀훅 -> api 함수 이와 같은 방향으로 api 함수를 호출하는데요.
(예를 들면 트레이너회원이 경력을 등록하는 경우엔 
`src/page/Career/RegisterCareer.tsx` -> `src/hooks/useCareer.ts` -> `src/api/career/postCareer.ts`)

회원가입, 로그인, 정보 입력 등등 api 함수를 호출하여 정보를 전송하고 나면 페이지를 이동시켜야 하는 경우가 많이 생깁니다. (ex: 경력을 등록하고 나면 마이페이지로 이동)
이런 상황에 `navigate`를 3가지 컴포넌트 중(페이지 컴포넌트, 관련 커스텀훅, api 함수) 어떤 컴포넌트에 두는 것이 좋을 지 고민이 됩니다!

현재 제 코드에서 경력을 등록하는 경우에는 페이지 컴포넌트`(src/pages/Career/RegisterCareer.tsx)`에서 `navigate`를 호출하고 있고,
로그인의 경우에는 `src/hooks/useLogin.tsx` 에서 `navigate`를 호출하고 있습니다.

전부 use~ 커스텀훅에서 호출하거나, api 함수에서 호출하도록 이 부분을 통일하는 것이 좋을 것 같아서, 주로 어떤 컴포넌트에서 `navigate`를 호출하는지 결정하고 통일하고 싶습니다!

---
안녕하세요 멘토님 ㅎㅎ
항상 열심히 피드백 해주시는 덕분에 발전하고 있다고 느낍니당 😊

이번 주차도 잘 부탁드립니다 매번 정말 감사드려요!
